### PR TITLE
[FEAT] 대체 버스 추천 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.3.0'
+	id 'org.springframework.boot' version '3.1.0'
 	id 'io.spring.dependency-management' version '1.1.5'
 }
 
@@ -26,9 +26,13 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'	
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// xml 응답을 위한 의존성
+	implementation 'org.glassfish.jaxb:jaxb-runtime:3.0.2'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cloudcomputing/ohhanahana/OhhanahanaApplication.java
+++ b/src/main/java/com/cloudcomputing/ohhanahana/OhhanahanaApplication.java
@@ -2,8 +2,9 @@ package com.cloudcomputing.ohhanahana;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 public class OhhanahanaApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/cloudcomputing/ohhanahana/controller/BusController.java
+++ b/src/main/java/com/cloudcomputing/ohhanahana/controller/BusController.java
@@ -1,0 +1,28 @@
+package com.cloudcomputing.ohhanahana.controller;
+
+import com.cloudcomputing.ohhanahana.dto.response.RecommendResponse;
+import com.cloudcomputing.ohhanahana.service.BusService;
+import jakarta.xml.bind.JAXBException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/bus")
+public class BusController {
+
+    private final BusService busService;
+
+    @GetMapping("/recommend")
+    public ResponseEntity<RecommendResponse> recommendBus() {
+        try {
+            RecommendResponse response = busService.getBusArrivalData(); // 인스턴스를 통해 메서드 호출
+            return ResponseEntity.ok(response);
+        } catch (JAXBException e) {
+            return ResponseEntity.status(500).body(null);
+        }
+    }
+}

--- a/src/main/java/com/cloudcomputing/ohhanahana/dto/response/RecommendResponse.java
+++ b/src/main/java/com/cloudcomputing/ohhanahana/dto/response/RecommendResponse.java
@@ -1,0 +1,33 @@
+package com.cloudcomputing.ohhanahana.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecommendResponse {
+    private List<Bus> buses;
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Bus {
+        private String busId;
+        private String busNumber;
+        private String busStopId;
+        private String busStopNumber;
+        private String busStopName;
+        private int remainTime;
+        private int remainBusStop;
+        private int congestion;
+
+
+        public void setBusNumber(String busNumber) {
+            this.busNumber = busNumber;
+        }
+    }
+}

--- a/src/main/java/com/cloudcomputing/ohhanahana/dto/response/ServiceResult.java
+++ b/src/main/java/com/cloudcomputing/ohhanahana/dto/response/ServiceResult.java
@@ -1,0 +1,62 @@
+package com.cloudcomputing.ohhanahana.dto.response;
+
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.Setter;
+
+import java.util.List;
+
+@XmlRootElement(name = "ServiceResult")
+@Setter
+public class ServiceResult {
+    private MsgBody msgBody;
+
+    @XmlElement(name = "msgBody")
+    public MsgBody getMsgBody() {
+        return msgBody;
+    }
+
+    @Setter
+    public static class MsgBody {
+        private List<Item> itemList;
+
+        @XmlElement(name = "itemList")
+        public List<Item> getItemList() {
+            return itemList;
+        }
+
+        @Setter
+        public static class Item {
+            private int arrivalEstimateTime;
+            private String bstopId;
+            private int congestion;
+            private int restStopCount;
+            private String routeId;
+
+            @XmlElement(name = "ARRIVALESTIMATETIME")
+            public int getArrivalEstimateTime() {
+                return arrivalEstimateTime;
+            }
+
+            @XmlElement(name = "BSTOPID")
+            public String getBstopId() {
+                return bstopId;
+            }
+
+            @XmlElement(name = "CONGESTION")
+            public int getCongestion() {
+                return congestion;
+            }
+
+            @XmlElement(name = "REST_STOP_COUNT")
+            public int getRestStopCount() {
+                return restStopCount;
+            }
+
+            @XmlElement(name = "ROUTEID")
+            public String getRouteId() {
+                return routeId;
+            }
+        }
+    }
+}

--- a/src/main/java/com/cloudcomputing/ohhanahana/enums/Bus.java
+++ b/src/main/java/com/cloudcomputing/ohhanahana/enums/Bus.java
@@ -1,0 +1,25 @@
+package com.cloudcomputing.ohhanahana.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Bus {
+    B_511("165000073", "511"),
+    B_13("165000016", "13"),
+    B_1601("165000154", "1601"),
+    B_38("165000006", "38"),
+    B_5_1("165000006", "5-1"),
+    B_512("165000074", "512"),
+    B_516("165000078", "516"),
+    B_519("165000081", "519"),
+    B_8("165000012", "8"),
+    B_801("169000027", "801"),
+    B_8A("165000364", "8A"),
+    B_31("168000040", "인천e음31")
+    ;
+    private final String busRouteId;
+    private final String busNumber;
+
+}

--- a/src/main/java/com/cloudcomputing/ohhanahana/enums/BusStop.java
+++ b/src/main/java/com/cloudcomputing/ohhanahana/enums/BusStop.java
@@ -1,0 +1,24 @@
+package com.cloudcomputing.ohhanahana.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BusStop {
+    INHA_BACK_GATE("163000165", "37165", "인하대후문"),
+    INHA_FRONT_GATE("163000099", "37099", "인하대정문"),
+    INHA_SUBWAY_4TH("163000122", "37122", "인하대역4번출구"),
+    INHA_SUBWAY_7TH("163000091", "37091", "인하대역7번출구"),
+    DGG("163000234", "37234", "독정이고개"),
+    YONGHYUN1("163000611", "37611", "용현고가교"),
+    YONGHYUN2("163000550", "37550", "용현고가교")
+
+    ;
+
+    private final String busStopId;
+    private final String busStopNumber;
+    private final String busStopName;
+
+
+}

--- a/src/main/java/com/cloudcomputing/ohhanahana/enums/Congestion.java
+++ b/src/main/java/com/cloudcomputing/ohhanahana/enums/Congestion.java
@@ -1,0 +1,18 @@
+package com.cloudcomputing.ohhanahana.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Congestion {
+
+    SPARE(1, "여유"),
+    NORMAL(2, "일반"),
+    CONGESTION(3, "혼잡"),
+    EXTRA(255, "모름")
+
+    ;
+    private final int number;
+    private final String toKorean;
+}

--- a/src/main/java/com/cloudcomputing/ohhanahana/service/BusService.java
+++ b/src/main/java/com/cloudcomputing/ohhanahana/service/BusService.java
@@ -1,0 +1,96 @@
+package com.cloudcomputing.ohhanahana.service;
+
+import com.cloudcomputing.ohhanahana.dto.response.RecommendResponse;
+import com.cloudcomputing.ohhanahana.enums.Bus;
+import com.cloudcomputing.ohhanahana.enums.BusStop;
+import com.cloudcomputing.ohhanahana.dto.response.ServiceResult;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class BusService {
+
+    private final String baseUri = "http://apis.data.go.kr/6280000/busArrivalService/getAllRouteBusArrivalList?serviceKey=";
+    private final String serviceKey = "MP/PZKljnnEeyzcpS63Gp64iWKeTktEfUPgTLTxUkeWfS9PhYf9ru7EG/cYyzR6oRkPIabAduj3ucpq0psgPHQ==";
+
+    public RecommendResponse getBusArrivalData() throws JAXBException {
+        List<BusStop> busStops = Arrays.stream(BusStop.values()).toList();
+
+        RestTemplate restTemplate = createRestTemplate();
+        List<RecommendResponse.Bus> buses = new ArrayList<>();
+
+        for (BusStop busStop : busStops) {
+            String apiUrl = baseUri + serviceKey
+                    + "&numOfRows=10&pageNo=1&bstopId=" + busStop.getBusStopId();
+
+            String response = restTemplate.getForObject(apiUrl, String.class);
+
+            if (response != null) {
+                JAXBContext jaxbContext = JAXBContext.newInstance(ServiceResult.class);
+                Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+                ServiceResult serviceResult = (ServiceResult) unmarshaller.unmarshal(new StringReader(response));
+
+                if (serviceResult.getMsgBody() != null && serviceResult.getMsgBody().getItemList() != null) {
+                    List<ServiceResult.MsgBody.Item> items = serviceResult.getMsgBody().getItemList();
+                    for (ServiceResult.MsgBody.Item item : items) {
+                        RecommendResponse.Bus bus = new RecommendResponse.Bus(
+                                item.getRouteId(),
+                                "",
+                                item.getBstopId(),
+                                busStop.getBusStopNumber(),
+                                busStop.getBusStopName(),
+                                item.getArrivalEstimateTime(),
+                                item.getRestStopCount(),
+                                item.getCongestion()
+                        );
+                        buses.add(bus);
+                    }
+                }
+            }
+        }
+
+        return validateBus(buses);
+    }
+
+    private RestTemplate createRestTemplate() {
+        RestTemplate restTemplate = new RestTemplate(clientHttpRequestFactory());
+        restTemplate.getMessageConverters().add(0, new StringHttpMessageConverter(StandardCharsets.UTF_8));
+        return restTemplate;
+    }
+
+    private ClientHttpRequestFactory clientHttpRequestFactory() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3000);
+        factory.setReadTimeout(3000);
+        return factory;
+    }
+
+    private RecommendResponse validateBus(List<RecommendResponse.Bus> buses) {
+
+        List<RecommendResponse.Bus> filteredBuses = buses.stream()
+                .filter(bus -> {
+                    for (Bus enumBus : Bus.values()) {
+                        if (enumBus.getBusRouteId().equals(bus.getBusId())) {
+                            bus.setBusNumber(enumBus.getBusNumber());
+                            return true;
+                        }
+                    }
+                    return false;
+                })
+                .toList();
+
+        return new RecommendResponse(filteredBuses);
+    }
+}

--- a/src/main/java/com/cloudcomputing/ohhanahana/service/BusService.java
+++ b/src/main/java/com/cloudcomputing/ohhanahana/service/BusService.java
@@ -1,9 +1,9 @@
 package com.cloudcomputing.ohhanahana.service;
 
 import com.cloudcomputing.ohhanahana.dto.response.RecommendResponse;
+import com.cloudcomputing.ohhanahana.dto.response.ServiceResult;
 import com.cloudcomputing.ohhanahana.enums.Bus;
 import com.cloudcomputing.ohhanahana.enums.BusStop;
-import com.cloudcomputing.ohhanahana.dto.response.ServiceResult;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
@@ -16,7 +16,9 @@ import org.springframework.web.client.RestTemplate;
 
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor


### PR DESCRIPTION
## 대체 버스 추천 API 구현
- 정해진 정류장 ID를 기반으로 버스 도착 정보를 가져와 추천 버스를 반환하는 API

### 주요 변경 사항
1. API 엔드포인트: /bus/recommend
2. ServiceResult 클래스: 외부 버스 도착 서비스로부터 XML 응답의 구조
3. RecommendResponse 클래스 추가: 버스 추천 API의 JSON 응답 구조
4. BusService 클래스:
5. Bus, BusStop, Congestion enum: 각각 버스, 정류장, 혼잡도 종류를 저장
6. UTF-8 인코딩 설정: `RestTemplate`을 UTF-8 인코딩을 사용하도록 설정
      ```java
      private RestTemplate createRestTemplate() {
          RestTemplate restTemplate = new RestTemplate(clientHttpRequestFactory());
          restTemplate.getMessageConverters().add(0, new StringHttpMessageConverter(StandardCharsets.UTF_8));
          return restTemplate;
      }
      ```
     - 이를 통해 외부 API로부터 한국어 문자가 포함된 응답을 올바르게 처리

---
### API 테스트
![image](https://github.com/cloud-computing-511/server/assets/30834810/c502ab95-6c92-4acb-9ba4-4e24f09b76a0)

---
### 의논할 사항
1. 특정 버스의 경우 여러 개의 정류장에서 조회가 되어 여러 개가 생김
    ex) 인하대 후문, 511, 1분전 / 용현사거리, 511, 3분전
2. 일부 버스는 시간대에 따라 조회가 안됨

위의 두 가지 사항 고려해서 뷰를 고민해야 함.